### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,10 +5,10 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-eCTRType_t		KEYWORD1
+eCTRType_t	KEYWORD1
 eWDTOutput_t	KEYWORD1
-eSQWRate_t		KEYWORD1		
-RTCConfig_t		KEYWORD1
+eSQWRate_t	KEYWORD1
+RTCConfig_t	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
@@ -26,10 +26,10 @@ RTC	KEYWORD2
 # Constants (LITERAL1)
 #######################################
 eALARM	LITERAL1
-eWATCHDOG	LITERAL1 
+eWATCHDOG	LITERAL1
 eRESET_PIN	LITERAL1
 eINT_PIN	LITERAL1
-e1Hz		LITERAL1
-e4kHz		LITERAL1
-e8kHz		LITERAL1
+e1Hz	LITERAL1
+e4kHz	LITERAL1
+e8kHz	LITERAL1
 e32kHz	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords